### PR TITLE
Changed version of doctrine/inflector to 1.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "symfony/process": "~2.3|~3.0",
         "zendframework/zendservice-apple-apns": "^1.1.0",
         "zendframework/zendservice-google-gcm": "1.*",
-        "doctrine/inflector": "~1.0"
+        "doctrine/inflector": "1.1"
     },
     "require-dev": {
         "atoum/atoum": "dev-master"


### PR DESCRIPTION
This is to prevent having to load php7 when using this library. doctrine/inflector version 1.2 requires php7.